### PR TITLE
doc: Fix the issue of overly lengthy examples in the Page Link section

### DIFF
--- a/.github/ISSUE_TEMPLATE/doc.yml
+++ b/.github/ISSUE_TEMPLATE/doc.yml
@@ -11,7 +11,7 @@ body:
     attributes:
       label: Page Link
       description: The URL of the page where the document is located.
-      placeholder: ex. https://github.com/kurosakishigure/katharsis/blob/canary/USE.md
+      placeholder: ex. https://example.com/docs/USE.md
   - type: textarea
     id: documentation_issue
     attributes:


### PR DESCRIPTION
* Fix the issue of overly lengthy examples in the Page Link section
