### PR TITLE
feat: Add cargo-deny-action to audit.yml

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,15 +6,12 @@ on:
   push:
     paths:
       - '**/Cargo.toml'
-      - '**/Cargo.lock'
-      - '**/audit.toml'
 
 jobs:
-  audit:
+  cargo-deny:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - uses: actions-rs/audit-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cargo deny
+        uses: EmbarkStudios/cargo-deny-action@v2

--- a/NOTICE
+++ b/NOTICE
@@ -18,3 +18,7 @@ This project includes third-party code under the following licenses:
   License: licenses/material-design-icons/LICENSE
   Repository: https://github.com/google/material-design-icons
   Copyright (c) 2024 Google, Inc.
+- MIT License:
+  License: licenses/tokio/LICENSE
+  Repository: https://github.com/tokio-rs/tokio
+  Copyright (c) Tokio Contributors

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,20 @@
+[graph]
+all-features = true
+
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "ISC",
+    "BSD-3-Clause",
+]
+
+[bans]
+multiple-versions = "allow"
+wildcards = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"

--- a/licenses/tokio/LICENSE
+++ b/licenses/tokio/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Tokio Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Description

- **feat: Add cargo-deny**
- **doc: Add tokio license**
- **feat: Add deny.toml**
- **What is the purpose of this PR?**
  - Enhance the `anti.yml` workflow
- **What problem does it solve?**
  - See [Checks](https://embarkstudios.github.io/cargo-deny/checks/index.html)
- **Are there any breaking changes or backwards compatibility issues?**
  - We have removed the `audit-check` as it is no longer maintained.
  - The `cargo-deny-action` handles various audit issues, such as license compliance. We have ensured that these licenses are compatible with MIT.

## Related Issue

- Closes #74

## Type of Change

- [x] New feature
- [x] Documentation update

## How Has This Been Tested?

- [x] I have run unit tests
- [x] I have tested the changes manually
- [x] I have tested in a staging environment

## Checklist

- [x] My code follows the coding style guidelines of this project
- [x] I have written or updated relevant documentation (if applicable)
- [x] I have added or updated tests to cover my changes (if applicable)
- [x] All new and existing tests pass
- [x] I have reviewed my code for any potential issues
- [x] Link the relevant issue to this PR (if applicable)
- [x] Add labels to this PR
- [x] I have read and followed the guidelines in `CONTRIBUTING.md`

## Additional Notes

None.
