### PR TITLE
fix: tempfile and tokio-test are categorized as dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,11 @@ inquire = "0.7.5"
 rss = "2.0.11"
 scraper = "0.22.0"
 serde = { version = "1.0.216", features = ["derive"] }
-tempfile = "3.14.0"
 thiserror = "2.0.6"
 tokio = { version = "1.42.0", features = ["fs", "io-util", "macros", "rt-multi-thread"] }
-tokio-test = "0.4.4"
 toml = "0.8.19"
 url = { version = "2.5.4", features = ["serde"] }
+
+[dev-dependencies]
+tokio-test = "0.4.4"
+tempfile = "3.14.0"

--- a/tests/katharsis.config.toml
+++ b/tests/katharsis.config.toml
@@ -7,7 +7,7 @@ site_url = "https://nextjs.org"
 image = "favicon.png"
 copyright = "© 2024 Vercel Inc"
 language = "en"
-output = "[temp]"
+output = ""
 
 [article]
 title = "h1"


### PR DESCRIPTION
## Description

- Fix `tempfile` and `tokio-test` are categorized as dependencies
- **What is the purpose of this PR?**
  - Classify as dev-dependencies
- **What problem does it solve?**
  - `tempfile` and `tokio-test` are categorized as dependencies  
- **Are there any breaking changes or backwards compatibility issues?**
  - Tests that rely on `rss.output = "[temp]"` will fail

## Related Issue

- Fixes #75

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

- [x] I have run unit tests
- [x] I have tested the changes manually
- [x] I have tested in a staging environment

## Checklist

- [x] My code follows the coding style guidelines of this project
- [ ] I have written or updated relevant documentation (if applicable)
- [x] I have added or updated tests to cover my changes (if applicable)
- [x] All new and existing tests pass
- [x] I have reviewed my code for any potential issues
- [x] Link the relevant issue to this PR (if applicable)
- [x] Add labels to this PR
- [x] I have read and followed the guidelines in `CONTRIBUTING.md`

## Additional Notes

None.
