### PR TITLE
fix: Incorrect timing of print statements

### DIFF
--- a/src/arg/handle.rs
+++ b/src/arg/handle.rs
@@ -216,10 +216,11 @@ pub async fn builder(config_path: &PathBuf) -> Result<Channel, Errors> {
             });
         }
 
-        println!("- create: {}", rss.output.to_string_lossy());
         if rss.output.as_os_str().is_empty() {
             Ok(channel_builder(rss, items))
         } else {
+            println!("- create: {}", rss.output.to_string_lossy());
+
             let mut rss_file = File::create(&rss.output).await?;
             let channel = channel_builder(rss, items);
 


### PR DESCRIPTION
## Description

- Fix incorrect timing of print statements
- **What is the purpose of this PR?**
  - Fixed a bug referenced in #79  
- **What problem does it solve?**
  - Resolved an issue in `arg::handle::builder` where the "- create:" message was printed at an inappropriate time.  
- **Are there any breaking changes or backwards compatibility issues?**
  - Now, if the provided `rss.output` is empty, no message will be displayed

## Related Issue

- Fixes #79

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

- [x] I have run unit tests
- [x] I have tested the changes manually
- [x] I have tested in a staging environment

## Checklist

- [x] My code follows the coding style guidelines of this project
- [ ] I have written or updated relevant documentation (if applicable)
- [ ] I have added or updated tests to cover my changes (if applicable)
- [x] All new and existing tests pass
- [x] I have reviewed my code for any potential issues
- [x] Link the relevant issue to this PR (if applicable)
- [x] Add labels to this PR
- [x] I have read and followed the guidelines in `CONTRIBUTING.md`

## Additional Notes

None.
