### PR TITLE
fix: ci.yml file is not triggered

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    tags: [ '[0-9]+.[0-9]+.[0-9]+', '[0-9]+.[0-9]+.[0-9]+-canary.[0-9]+' ]
   pull_request:
     branches: [ 'canary' ]
 


### PR DESCRIPTION
## Description

- Fix ci.yml file is not triggered
- **What is the purpose of this PR?**
  - Fixed a bug referenced in #84  
- **What problem does it solve?** 
  - See #84 
- **Are there any breaking changes or backwards compatibility issues?**
  - When a new tag is released, the `ci.yml` file will be triggered

## Related Issue

- Fixes #84

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

- [x] I have run unit tests
- [x] I have tested the changes manually
- [x] I have tested in a staging environment

## Checklist

- [x] My code follows the coding style guidelines of this project
- [ ] I have written or updated relevant documentation (if applicable)
- [ ] I have added or updated tests to cover my changes (if applicable)
- [x] All new and existing tests pass
- [x] I have reviewed my code for any potential issues
- [x] Link the relevant issue to this PR (if applicable)
- [x] Add labels to this PR
- [x] I have read and followed the guidelines in `CONTRIBUTING.md`

## Additional Notes

This issue occurred due to my oversight.
