### PR TITLE
chore: Change the _ in the build artifact filenames to -

### DIFF
--- a/etc/cd/before_deploy.sh
+++ b/etc/cd/before_deploy.sh
@@ -150,7 +150,7 @@ Conflicts: $conflictname
 Description: CLI tool for generating RSS feeds.
 EOF
 
-    fakeroot dpkg-deb -Zxz --build "$tempdir" "${dpkgname}_v${version}_${architecture}.deb"
+    fakeroot dpkg-deb -Zxz --build "$tempdir" "${dpkgname}-v${version}-${architecture}.deb"
 }
 
 


### PR DESCRIPTION
## Description

- **What is the purpose of this PR?**
  - Change the `_` in the build artifact filenames to `-`  
- **What problem does it solve?**
  - The file name formats are inconsistent  
- **Are there any breaking changes or backwards compatibility issues?**
  - None

## Related Issue

None.

## Type of Change

- [x] Miscellaneous tasks

## How Has This Been Tested?

- [x] I have run unit tests
- [x] I have tested the changes manually
- [x] I have tested in a staging environment

## Checklist

- [x] My code follows the coding style guidelines of this project
- [ ] I have written or updated relevant documentation (if applicable)
- [ ] I have added or updated tests to cover my changes (if applicable)
- [x] All new and existing tests pass
- [x] I have reviewed my code for any potential issues
- [ ] Link the relevant issue to this PR (if applicable)
- [x] Add labels to this PR
- [x] I have read and followed the guidelines in `CONTRIBUTING.md`

## Additional Notes

None.
