### PR TITLE
revert: Ensure the naming conventions of deb build artifacts

### DIFF
--- a/etc/cd/before_deploy.sh
+++ b/etc/cd/before_deploy.sh
@@ -150,7 +150,7 @@ Conflicts: $conflictname
 Description: CLI tool for generating RSS feeds.
 EOF
 
-    fakeroot dpkg-deb -Zxz --build "$tempdir" "${dpkgname}-v${version}-${architecture}.deb"
+    fakeroot dpkg-deb -Zxz --build "$tempdir" "${dpkgname}_v${version}_${architecture}.deb"
 }
 
 

--- a/etc/cd/before_deploy.sh
+++ b/etc/cd/before_deploy.sh
@@ -150,7 +150,7 @@ Conflicts: $conflictname
 Description: CLI tool for generating RSS feeds.
 EOF
 
-    fakeroot dpkg-deb -Zxz --build "$tempdir" "${dpkgname}_v${version}_${architecture}.deb"
+    fakeroot dpkg-deb -Zxz --build "$tempdir" "${dpkgname}_${version}_${architecture}.deb"
 }
 
 


### PR DESCRIPTION
## Description

- Change the - in the build artifact filenames to _                                                                                                                    
- Remove v to complete the versioning in the artifact file name
- **What is the purpose of this PR?** 
  - Ensure the naming conventions of deb build artifacts 
- **What problem does it solve?**  
  - This PR reverts #117 and #115 to make the build artifacts conform to the naming conventions
- **Are there any breaking changes or backwards compatibility issues?**
  - As a result, the naming of the build artifacts will no longer be consistent with those from older tagged releases

## Related Issue

None.

## Type of Change

- [x] Reverts commit

## How Has This Been Tested?

- [x] I have run unit tests
- [x] I have tested the changes manually
- [x] I have tested in a staging environment

## Checklist

- [x] My code follows the coding style guidelines of this project
- [ ] I have written or updated relevant documentation (if applicable)
- [ ] I have added or updated tests to cover my changes (if applicable)
- [x] All new and existing tests pass
- [x] I have reviewed my code for any potential issues
- [ ] Link the relevant issue to this PR (if applicable)
- [x] Add labels to this PR
- [x] I have read and followed the guidelines in `CONTRIBUTING.md`

## Additional Notes

None.
