### PR TITLE
fix: Release.tag_name already exists

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -85,26 +85,8 @@ jobs:
       - name: Releasing assets
         uses: softprops/action-gh-release@v2
         with:
+          prerelease: ${{ contains(github.ref_name, 'canary') }}
+          generate_release_notes: true
           files: |
             katharsis-*-${{ matrix.job.target }}.*
             katharsis*.deb
-
-  create-release-note:
-    permissions:
-      contents: write
-    needs: publish
-    runs-on: ubuntu-latest
-    name: Create release note
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Create release note
-        run: |
-          if [[ "${TAG_NAME}" == *canary* ]]; then
-            gh release create "${TAG_NAME}" -p --generate-notes
-          else
-            gh release create "${TAG_NAME}" --generate-notes
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ github.ref_name }}


### PR DESCRIPTION
### Description

- **What is the purpose of this PR?**
  - Fixed [12541278748](https://github.com/kurosakishigure/katharsis/actions/runs/12541278748)
- **What problem does it solve?**
- **Are there any breaking changes or backwards compatibility issues?**

### Related Issue

### Type of Change

- [x] Bug fix

### How Has This Been Tested?

- [ ] I have run unit tests
- [ ] I have tested the changes manually
- [ ] I have tested in a staging environment

### Checklist

- [x] I have read and followed the guidelines in `CONTRIBUTING.md`
- [ ] I have already updated the related templates accordingly (if applicable)
- [ ] I have written or updated relevant documentation (if applicable)
- [ ] I have added or updated tests to cover my changes (if applicable)
- [x] I have reviewed my code for any potential issues

### Additional Notes

