### PR TITLE
ci(json-analyzer): add the `-q` parameter

### DIFF
--- a/.github/workflows/json-analyzer.yml
+++ b/.github/workflows/json-analyzer.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Run jsonlint
         run: |
           shopt -s globstar
-          jsonlint changelogithub.config.json
+          jsonlint changelogithub.config.json -q


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!-- Thanks for opening a PR! Your contribution is much appreciated -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. Commit message (if applicable)

### Description

<!-- Explain the reason for the changes -->

- **What is the purpose of this PR?**
  - Close the file content printed when lint passes.
- **What problem does it solve?**
  - Since these outputs are meaningless, the `-q` parameter should be used for quiet output.
- **Are there any breaking changes or backwards compatibility issues?**
  - (if applicable)

### Related Issue

<!-- If this PR addresses an existing issue, please provide a reference to it -->

- Closes #number (if applicable)

### Checklist

<!-- Please check the following before submitting the PR -->

- [x] I have read and followed the guidelines in `CONTRIBUTING.md`
- [ ] I have already updated the related examples accordingly (if applicable)
- [ ] I have written or updated relevant docs (if applicable)
- [ ] I have already updated the related CI config accordingly (if applicable)
- [ ] I have added or updated tests to cover my changes (if applicable)
- [ ] I have already updated the related build system accordingly (if applicable)
- [x] I have reviewed my code for any potential issues

### Additional Notes

<!-- Any additional information -->

(if applicable)
