### PR TITLE
fix(typos_config): the scope of path exclusions is incorrect

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,9 +1,11 @@
 [files]
 extend-exclude = [
-  "LICENSES",
-  "assets",
-  "docs",
-  "examples",
+  ".*/**",
+  ".*",
+  "LICENSES/**",
+  "assets/**",
+  "docs/**",
+  "examples/**",
   'Cargo.lock',
   'Cargo.toml',
   "LICENSE",


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!-- Thanks for opening a PR! Your contribution is much appreciated -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. Commit message (if applicable)

### Description

<!-- Explain the reason for the changes -->

- **What is the purpose of this PR?**
  - (if applicable)
- **What problem does it solve?**
  - We noticed that when using `typos-lsp`, the scope for some paths is not being applied, so we added the complete regex.
- **Are there any breaking changes or backwards compatibility issues?**
  - (if applicable)

### Related Issue

<!-- If this PR addresses an existing issue, please provide a reference to it -->

- Closes #number (if applicable)

### Checklist

<!-- Please check the following before submitting the PR -->

- [x] I have read and followed the guidelines in `CONTRIBUTING.md`
- [ ] I have already updated the related examples accordingly (if applicable)
- [ ] I have written or updated relevant docs (if applicable)
- [ ] I have already updated the related CI config accordingly (if applicable)
- [ ] I have added or updated tests to cover my changes (if applicable)
- [ ] I have already updated the related build system accordingly (if applicable)
- [x] I have reviewed my code for any potential issues

### Additional Notes

<!-- Any additional information -->

(if applicable)
