### PR TITLE
fix(vale_config): the `glob` does not match files when using `vale-ls` in `nvim`

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -3,5 +3,5 @@ MinAlertLevel = error
 Packages = Google
 Vocab = Tech
 
-[{.github/**/*,docs/**/*,examples/**/*,README}.md]
+[*.md]
 BasedOnStyles = Vale, Google


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!-- Thanks for opening a PR! Your contribution is much appreciated -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. Commit message (if applicable)

### Description

<!-- Explain the reason for the changes -->

- **What is the purpose of this PR?**
  - (if applicable)
- **What problem does it solve?**
  - In `nvim`, `vale-ls` doesn't work as expected because the `glob` rules in the `.vale.ini` file never match the file itself.
- **Are there any breaking changes or backwards compatibility issues?**
  - This will obviously affect some files that should not be covered by the rules, such as `LICENSES/nextjs/license.md`.

### Related Issue

<!-- If this PR addresses an existing issue, please provide a reference to it -->

- Closes #number (if applicable)

### Checklist

<!-- Please check the following before submitting the PR -->

- [x] I have read and followed the guidelines in `CONTRIBUTING.md`
- [ ] I have already updated the related examples accordingly (if applicable)
- [ ] I have written or updated relevant docs (if applicable)
- [ ] I have already updated the related CI config accordingly (if applicable)
- [ ] I have added or updated tests to cover my changes (if applicable)
- [ ] I have already updated the related build system accordingly (if applicable)
- [x] I have reviewed my code for any potential issues

### Additional Notes

<!-- Any additional information -->

(if applicable)
