### PR TITLE
docs(discussion_template): fix the formatting error in the `ideas.yml` file

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -3,8 +3,7 @@ body:
     attributes:
       label: Goals
       description: Short list of what the feature request aims to address?
-      value: |
-        1.
+      value: '1.'
     validations:
       required: true
   - type: textarea

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -3,7 +3,8 @@ body:
     attributes:
       label: Goals
       description: Short list of what the feature request aims to address?
-      value: '1.'
+      value: |
+        1.
     validations:
       required: true
   - type: textarea

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -3,7 +3,7 @@ body:
     attributes:
       label: Goals
       description: Short list of what the feature request aims to address?
-      value: 1.
+      value: '1.'
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!-- markdownlint-disable-file MD041 -->

<!-- Thanks for opening a PR! Your contribution is much appreciated -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. (if applicable)

### Description

<!-- Explain the reason for the changes -->

- **What is the purpose of this PR?**
  - (if applicable)
- **What problem does it solve?**
  - <img width="792" alt="Screenshot 2025-02-17 at 1 29 31 AM" src="https://github.com/user-attachments/assets/391eadee-14c3-4b01-b813-6d50743a4ae3" />

- **Are there any breaking changes or backwards compatibility issues?**
  - (if applicable)

### Related Issue

<!-- If this PR addresses an existing issue, please provide a reference to it -->

- #number (if applicable)

### Checklist

<!-- Please check the following before submitting the PR -->

- [x] I have read and followed the guidelines in `CONTRIBUTING.md`
- [ ] I have already updated the related examples accordingly (if applicable)
- [ ] I have written or updated relevant docs (if applicable)
- [ ] I have already updated the related CI config accordingly (if applicable)
- [ ] I have added or updated tests to cover my changes (if applicable)
- [ ] I have already updated the related build system accordingly (if applicable)
- [x] I have reviewed my code for any potential issues

### Additional Notes

<!-- Any additional information -->

Due to an issue with GitHub, the error messages in the development branch (`docs/fix_discussion_template`) are **false positives**.
