### PR TITLE
fix(ci): restrict the matching scope of the labeler's globs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,10 +12,10 @@ docs:
 chore:
   - changed-files:
       - any-glob-to-any-file:
-          - '/*.yml'
-          - '/*.toml'
-          - '/*.json'
-          - '/*.ini'
+          - './*.yml'
+          - './*.toml'
+          - './*.json'
+          - './*.ini'
           - '.config/**'
           - 'assets/**'
           - '.gitignore'


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!--

Thanks for opening a PR! Your contribution is much appreciated.

NOTE: Please fill in the `(if applicable)` sections of the template as needed based on your situation. We encourage you to provide as much detail as possible.

-->

<!-- markdownlint-disable-file MD041 -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. (if applicable)

### Description

<!-- Explain the reason for the changes -->

- **What is the purpose of this PR?**
  - (if applicable)
- **What problem does it solve?**
  - (if applicable)
- **Are there any breaking changes or backwards compatibility issues?**
  - (if applicable)

### Related Issue

<!-- If this PR addresses an existing issue, please provide a reference to it -->

- #NUMBER (if applicable)

### Checklist

<!-- Please check the following before submitting the PR -->

- [x] I have read and followed the guidelines in `CONTRIBUTING.md`
- [ ] I have already updated the related examples accordingly (if applicable)
- [ ] I have written or updated relevant docs (if applicable)
- [ ] I have already updated the related CI config accordingly (if applicable)
- [ ] I have added or updated tests to cover my changes (if applicable)
- [ ] I have already updated the related build system accordingly (if applicable)
- [x] I have reviewed my code for any potential issues

### Additional Notes

<!-- Any additional information -->

(if applicable)
