### PR TITLE
fix(dependabot): dependabot does not follow `labels: []`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+# FIX: If `labels: ['foo']` is not explicitly configured, Dependabot will not follow `labels: []`. (#395-396)
 version: 2
 updates:
   - package-ecosystem: cargo
@@ -5,13 +6,13 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
-    labels: []
+    labels: ['build']
     commit-message:
       prefix: 'build(deps)'
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
       interval: daily
-    labels: []
+    labels: ['ci']
     commit-message:
       prefix: 'ci(deps)'


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!--

Thanks for opening a PR! Your contribution is much appreciated.

NOTE: We encourage you to provide as much detail as possible.

-->

<!-- markdownlint-disable-file MD041 -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. CHANGE_SUMMARY

### Description

<!-- Explain the reason for the changes -->

- **What does this PR do?**
  - EXPLAIN_HERE
- **Which issue does it resolve?**
  - Closes #ISSUE_NUMBER
- **Does this introduce breaking changes?**
  - EXPLAIN_HERE

### Checklist

<!-- Please check the following before submitting the PR -->

- [x] I have followed the contribution guidelines.
- [ ] I have updated the build system.
- [ ] I have updated the examples.
- [ ] I have updated the tests.
- [ ] I have updated the documentation.
- [ ] I have updated the CI pipeline.
- [x] I have reviewed my changes.

### Additional Notes

<!-- Any additional information -->
