### PR TITLE
ci(commit_analyzer): drop the commit message compliance check, keep validating PR titles

### DIFF
--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -1,19 +1,15 @@
-name: Commit Analyzer
+name: Validate PR Title
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 on:
   pull_request:
-    types: [opened, edited, synchronize]
+    types: [opened, edited]
 jobs:
   commitlint:
     runs-on: ubuntu-latest
     name: commitlint
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Set nodejs
         uses: actions/setup-node@v4
         with:
@@ -25,6 +21,3 @@ jobs:
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: echo "$TITLE" | npx commitlint@latest -V
-      - name: Validate PR commits with commitlint
-        if: ${{ !github.event.pull_request.merged }}
-        run: npx commitlint@latest -f ${{ github.event.pull_request.base.sha }} -t ${{ github.event.pull_request.head.sha }} -V

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     name: commitlint
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Set nodejs
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!--

Thanks for opening a PR! Your contribution is much appreciated.

NOTE: We encourage you to provide as much detail as possible.

-->

<!-- markdownlint-disable-file MD041 -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. CHANGE_SUMMARY

### Description

<!-- Explain the reason for the changes -->

- **What does this PR do?**
  - Since DCO remediation could be affected and force-push is disabled by branch protection rules,
    there's no need to check the commit messages in the PR branch when the merge method is always set to squash.
    In this case, only the PR title needs to be validated. 
  - See [#218 commits](https://github.com/arghena/katharsis/pull/218/commits/0bafa7f62e36ad33278955c574efe11833610995), [defaults.ts](https://github.com/conventional-changelog/commitlint/blob/master/%40commitlint/is-ignored/src/defaults.ts)
- **Which issue does it resolve?**
  - Closes #ISSUE_NUMBER
- **Does this introduce breaking changes?**
  - EXPLAIN_HERE

### Checklist

<!-- Please check the following before submitting the PR -->

- [x] I have followed the contribution guidelines.
- [ ] I have updated the build system.
- [ ] I have updated the examples.
- [ ] I have updated the tests.
- [ ] I have updated the documentation.
- [ ] I have updated the CI pipeline.
- [x] I have reviewed my changes.

### Additional Notes

<!-- Any additional information -->
