### PR TITLE
ci(tombi): add the `--error-on-warnings` linter arg

### DIFF
--- a/.github/insight.toml
+++ b/.github/insight.toml
@@ -29,6 +29,7 @@ cargo_tarpaulin = [
   "target/tarpaulin",
 ]
 yamllint = ["--strict"]
+tombi = ["--error-on-warnings"]
 
 [formatters]
 cargo_fmt = ["**/*.rs", "Cargo.toml"]


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!--

Thanks for opening a PR! Your contribution is much appreciated.

NOTE: We encourage you to provide as much detail as possible.

-->

<!-- markdownlint-disable-file MD041 -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. CHANGE_SUMMARY

### Description

<!-- Explain the reason for the changes -->

- **What does this PR do?**
  - Sync https://github.com/arghena/assets/pull/35
- **Which issue does it resolve?**
  - Closes #ISSUE_NUMBER
- **Does this introduce breaking changes?**
  - EXPLAIN_HERE

### Checklist

<!-- Please check the following before submitting the PR -->

- [x] I have followed the contribution guidelines.
- [ ] I have updated the build system.
- [ ] I have updated the examples.
- [ ] I have updated the tests.
- [ ] I have updated the documentation.
- [ ] I have updated the CI pipeline.
- [x] I have reviewed my changes.

### Additional Notes

<!-- Any additional information -->
