### PR TITLE
ci(before_deploy): use tildes instead of hyphens for proper Debian versioning

### DIFF
--- a/etc/ci/before_deploy.sh
+++ b/etc/ci/before_deploy.sh
@@ -83,7 +83,7 @@ make_deb() {
             return 0
             ;;
     esac
-    version=${GITHUB_REF/refs\/tags\/v/}
+    version=$(echo "$GITHUB_REF_NAME" | sed -e 's/^v//' -e 's/-canary/~canary/')
 
     if [[ $TARGET = *musl* ]]; then
         dpkgname=$PROJECT_NAME-musl


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!--

Thanks for opening a PR! Your contribution is much appreciated.

NOTE: We encourage you to provide as much detail as possible.

-->

<!-- markdownlint-disable-file MD041 -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. CHANGE_SUMMARY

### Description

<!-- Explain the reason for the changes -->

- **What does this PR do?**
  - EXPLAIN_HERE
- **Which issue does it resolve?**
  - Closes #ISSUE_NUMBER
- **Does this introduce breaking changes?**
  - EXPLAIN_HERE

### Checklist

<!-- Please check the following before submitting the PR -->

- [x] I have followed the contribution guidelines.
- [ ] I have updated the build system.
- [ ] I have updated the examples.
- [ ] I have updated the tests.
- [ ] I have updated the documentation.
- [ ] I have updated the CI pipeline.
- [x] I have reviewed my changes.

### Additional Notes

<!-- Any additional information -->

https://www.debian.org/doc/manuals/debmake-doc/ch06.en.html
