### PR TITLE
fix: reorder attributes on `main` to fix `rust-analyzer` error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,8 @@ struct Cli {
     command: Option<Commands>,
 }
 
-#[cfg(not(tarpaulin_include))]
 #[tokio::main]
+#[cfg(not(tarpaulin_include))]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
     let mut path = PathBuf::from("katharsis.toml");


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!--

Thanks for opening a PR! Your contribution is much appreciated.

NOTE: We encourage you to provide as much detail as possible.

-->

<!-- markdownlint-disable-file MD041 -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. CHANGE_SUMMARY

### Description

<!-- Explain the reason for the changes -->

- **What does this PR do?**
  - EXPLAIN_HERE
- **Which issue does it resolve?**
  - Closes #ISSUE_NUMBER
- **Does this introduce breaking changes?**
  - EXPLAIN_HERE

### Checklist

<!-- Please check the following before submitting the PR -->

- [x] I have followed the contribution guidelines.
- [ ] I have updated the build system.
- [ ] I have updated the examples.
- [ ] I have updated the tests.
- [ ] I have updated the documentation.
- [ ] I have updated the CI pipeline.
- [x] I have reviewed my changes.

### Additional Notes

<!-- Any additional information -->

Swapped the order of `#[tokio::main]` and `#[cfg(...)]` to resolve the
false positive `missing async keyword` error in the IDE.
