### PR TITLE
ci(cd): split binutils install into separate steps

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -62,17 +62,16 @@ jobs:
           else
             cargo build --release --locked --target ${{ matrix.job.target }}
           fi
-      - name: Install required dependencies
-        shell: bash
+      - name: Install binutils for ARM32
+        if: ${{ matrix.job.target == 'arm-unknown-linux-gnueabihf' }}
         run: |
-          if [[ ${{ matrix.job.target }} == arm-unknown-linux-gnueabihf ]]; then
-              sudo apt update
-              sudo apt install -y binutils-arm-linux-gnueabihf
-          fi
-          if [[ ${{ matrix.job.target }} == aarch64-unknown-linux-gnu ]]; then
-              sudo apt update
-              sudo apt install -y binutils-aarch64-linux-gnu
-          fi
+          sudo apt update
+          sudo apt install -y binutils-arm-linux-gnueabihf
+      - name: Install binutils for ARM64
+        if: ${{ matrix.job.target == 'aarch64-unknown-linux-gnu' }}
+        run: |
+          sudo apt update
+          sudo apt install -y binutils-aarch64-linux-gnu
       - name: Packaging final binary
         shell: bash
         env:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,7 +45,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Rust stable
-        shell: bash
         run: |
           rustup toolchain install stable --profile minimal --no-self-update
           rustup override set stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Rust stable
-        shell: bash
         run: |
           rustup toolchain install stable --profile minimal --no-self-update
           rustup override set stable
@@ -94,7 +93,6 @@ jobs:
       - name: Run doctests
         # TODO: Waiting for nextest to support doctests.
         # https://github.com/nextest-rs/nextest/issues/16
-        shell: bash
         if: ${{ !matrix.job.use-cross }}
         run: cargo test --doc --locked --target ${{ matrix.job.target }}
 
@@ -115,7 +113,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Rust stable
-        shell: bash
         run: |
           rustup toolchain install stable --profile minimal --no-self-update
           rustup override set stable
@@ -124,15 +121,11 @@ jobs:
         with:
           save-if: ${{ github.ref_name == 'canary' }}
       - name: Build for release
-        shell: bash
         run: cargo build --release --locked --target ${{ matrix.target }}
       - name: End to end tests
-        shell: bash
         run: |
-          cli="cargo run --release --locked --target ${{ matrix.target }}"
-
-          $cli init
-          $cli
+          cargo run --release --locked --target ${{ matrix.target }} init
+          cargo run --release --locked --target ${{ matrix.target }}
 
   docs:
     name: Docs


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!--

Thanks for opening a PR! Your contribution is much appreciated.

NOTE: We encourage you to provide as much detail as possible.

-->

<!-- markdownlint-disable-file MD041 -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. ci(cd): split binutils install into separate steps
2. ci: drop redundant `shell: bash` lines

### Description

<!-- Explain the reason for the changes -->

- **What does this PR do?**
  - EXPLAIN_HERE
- **Which issue does it resolve?**
  - Closes #ISSUE_NUMBER
- **Does this introduce breaking changes?**
  - EXPLAIN_HERE

### Checklist

<!-- Please check the following before submitting the PR -->

- [x] I have followed the contribution guidelines.
- [ ] I have updated the build system.
- [ ] I have updated the examples.
- [ ] I have updated the tests.
- [ ] I have updated the documentation.
- [ ] I have updated the CI pipeline.
- [x] I have reviewed my changes.

### Additional Notes

<!-- Any additional information -->
