### PR TITLE
ci(deps): bump arghena/insight from 0.1.0-canary.31 to 0.1.0-canary.32

### DIFF
--- a/.github/insight.toml
+++ b/.github/insight.toml
@@ -45,5 +45,6 @@ cargo-tarpaulin = [
   "--output-dir",
   "target/tarpaulin",
 ]
+commitlint = ["--strict"]
 yamllint = ["--strict"]
 tombi = ["--error-on-warnings"]

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run Insight
-        uses: arghena/insight@2b8f06b7dd47fce33051fbf06789c519218ae6bc # v0.1.0-canary.31
+        uses: arghena/insight@830a052a4d8a1749c1105b62ece759ce088d82e8 # v0.1.0-canary.32

--- a/.github/workflows/check-pull-request-title.yml
+++ b/.github/workflows/check-pull-request-title.yml
@@ -17,9 +17,7 @@ jobs:
     if: ${{ github.event.action == 'opened' || github.event.changes.title != null }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run Insight
-        uses: arghena/insight@2b8f06b7dd47fce33051fbf06789c519218ae6bc # v0.1.0-canary.31
+        uses: arghena/insight@830a052a4d8a1749c1105b62ece759ce088d82e8 # v0.1.0-canary.32
         with:
           check-pull-request-title: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run Insight
-        uses: arghena/insight@2b8f06b7dd47fce33051fbf06789c519218ae6bc # v0.1.0-canary.31
+        uses: arghena/insight@830a052a4d8a1749c1105b62ece759ce088d82e8 # v0.1.0-canary.32
       - name: Upload to Coveralls
         if: ${{ github.ref_type == 'tag' }}
         uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!-- markdownlint-disable-file MD041 -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. CHANGE_SUMMARY

### Description

<!-- Explain the reason for the changes -->

- **What does this PR do?**
  - EXPLAIN_HERE
- **Which issue does it resolve?**
  - Closes #ISSUE_NUMBER
- **Does this introduce breaking changes?**
  - EXPLAIN_HERE

### Additional Notes

<!-- Any additional information -->
