### PR TITLE
ci(codeql): remove redundant `security-extended` query

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,7 +43,7 @@ jobs:
           # NOTE: Rust is only supported with `build-mode: none`.
           # https://github.com/orgs/community/discussions/161754#discussioncomment-14025580
           build-mode: none
-          queries: security-extended,security-and-quality
+          queries: security-and-quality
           languages: ${{ matrix.language }}
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@9e907b5e64f6b83e7804b09294d44122997950d6 # v4.32.3


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!-- markdownlint-disable-file MD041 -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. CHANGE_SUMMARY

### Description

<!-- Explain the reason for the changes -->

- **What does this PR do?**
  - EXPLAIN_HERE
- **Which issue does it resolve?**
  - Closes #ISSUE_NUMBER
- **Does this introduce breaking changes?**
  - EXPLAIN_HERE

### Additional Notes

<!-- Any additional information -->

[Using queries in QL packs](https://docs.github.com/en/code-security/how-tos/scan-code-for-vulnerabilities/configure-code-scanning/customizing-your-advanced-setup-for-code-scanning#using-queries-in-ql-packs)
[CodeQL query help](https://codeql.github.com/codeql-query-help)
