### PR TITLE
ci(concurrency): use ref_name instead of sha to avoid wasteful parallel runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,7 +1,7 @@
 name: CodeQL
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
 
 # https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/#languages-and-compilers

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 name: Lint
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!-- markdownlint-disable-file MD041 -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. CHANGE_SUMMARY

### Description

<!-- Explain the reason for the changes -->

- **What does this PR do?**
  - EXPLAIN_HERE
- **Which issue does it resolve?**
  - Closes #ISSUE_NUMBER
- **Does this introduce breaking changes?**
  - EXPLAIN_HERE

### Additional Notes

<!-- Any additional information -->
