### PR TITLE
ci(codecov): swap tarpaulin for llvm-cov and move to codecov

### DIFF
--- a/.github/insight.toml
+++ b/.github/insight.toml
@@ -4,12 +4,8 @@ dot = true
 [schedule]
 linters = ["cargo-deny"]
 
-[push]
-formatters = ["cargo-fmt"]
-linters = ["cargo-msrv", "cargo-clippy", "cargo-tarpaulin", "ast-grep"]
-
 [formatters]
-cargo-fmt = ["**/*.rs", "Cargo.toml"]
+cargo-fmt = ["**/*.rs"]
 prettier = ["**/*.yml", "**/*.md", "**/*.json"]
 tombi = ["**/*.toml"]
 shfmt = ["etc/ci/*.sh"]
@@ -17,9 +13,8 @@ shfmt = ["etc/ci/*.sh"]
 [linters]
 cargo-deny = ["Cargo.toml", "Cargo.lock"]
 typos = ["**/*", "!examples/**/*.png"]
-cargo-msrv = ["**/*.rs", "Cargo.toml"]
-cargo-clippy = ["**/*.rs", "Cargo.toml"]
-cargo-tarpaulin = ["**/*.rs", "Cargo.toml"]
+cargo-msrv = ["**/*.rs", "Cargo.toml", "Cargo.lock"]
+cargo-clippy = ["**/*.rs", "Cargo.toml", "Cargo.lock"]
 yamllint = ["**/*.yml"]
 actionlint = [".github/workflows/*.yml"]
 ast-grep = ["**/*.rs"]
@@ -35,18 +30,6 @@ shfmt = ["-i", "4", "-ci"]
 
 [args.linters]
 cargo-clippy = ["--all-targets", "--locked", "--", "-D", "warnings"]
-# NOTE: `--engine llvm` and `--release` cause the test coverage to be inaccurate.
-cargo-tarpaulin = [
-  "--locked",
-  "--fail-under",
-  "80",
-  "--engine",
-  "ptrace",
-  "--out",
-  "lcov",
-  "--output-dir",
-  "target/tarpaulin",
-]
 commitlint = ["--strict"]
 yamllint = ["--strict"]
 tombi = ["--error-on-warnings"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,16 +6,11 @@ concurrency:
 
 on:
   push:
-    # NOTE: Caches from base branches are available to PRs and tags, but not across unrelated branches.
-    # https://github.com/Swatinem/rust-cache/blob/master/README.md#cache-limits-and-control
     branches: [canary]
     paths:
-      # https://github.com/Swatinem/rust-cache/blob/master/README.md#cache-details
+      - '**/*.rs'
       - '**/Cargo.toml'
       - '**/Cargo.lock'
-    # NOTE: Path filters are not evaluated for pushes of tags.
-    # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpushpull_requestpull_request_targetpathspaths-ignore
-    tags: ['v[0-9]+.[0-9]+.[0-9]+', 'v[0-9]+.[0-9]+.[0-9]+-canary.[0-9]+']
   pull_request:
     paths:
       - '**/*.rs'
@@ -146,3 +141,46 @@ jobs:
         run: cargo doc --no-deps --document-private-items --locked
         env:
           RUSTDOCFLAGS: -D warnings
+
+  coverage:
+    permissions:
+      id-token: write
+      contents: read
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      # NOTE: Nightly Rust is required for `cargo llvm-cov --doc`.
+      # https://github.com/taiki-e/cargo-llvm-cov/issues/2
+      # https://nexte.st/docs/integrations/test-coverage/#collecting-coverage-data-from-doctests
+      - name: Install Rust nightly
+        run: |
+          rustup toolchain install nightly --profile minimal --no-self-update
+          rustup override set nightly
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          save-if: ${{ github.ref_name == 'canary' }}
+      - name: Install llvm-tools-preview component
+        run: rustup component add llvm-tools-preview
+      - name: Install llvm-cov
+        uses: taiki-e/install-action@2723513a70062521fb56e5df87a04967751efd2f # v2.68.4
+        with:
+          tool: cargo-llvm-cov
+      - name: Install nextest
+        uses: taiki-e/install-action@2723513a70062521fb56e5df87a04967751efd2f # v2.68.4
+        with:
+          tool: cargo-nextest
+      - name: Collect coverage data
+        run: |
+          cargo llvm-cov --locked --no-report nextest
+          cargo llvm-cov --locked --no-report --doc
+          cargo llvm-cov report --locked --doctests --lcov --output-path lcov.info
+        env:
+          RUSTDOCFLAGS: -D warnings
+      - name: Upload coverage data to codecov
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        with:
+          use_oidc: true
+          files: lcov.info

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,12 +1,10 @@
 name: Lint
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 on:
-  push:
-    tags: ['v[0-9]+.[0-9]+.[0-9]+', 'v[0-9]+.[0-9]+.[0-9]+-canary.[0-9]+']
   pull_request:
     types: [opened, synchronize]
 
@@ -22,8 +20,3 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run Insight
         uses: arghena/insight@830a052a4d8a1749c1105b62ece759ce088d82e8 # v0.1.0-canary.32
-      - name: Upload to Coveralls
-        if: ${{ github.ref_type == 'tag' }}
-        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
-        with:
-          file: './target/tarpaulin/lcov.info'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,9 @@ tokio-test = "0.4.5"
 pedantic = "warn"
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(tarpaulin_include)"] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+  "cfg(coverage,coverage_nightly)"
+] }
 
 [profile.release]
 strip = true

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ This is because users won't have access to those files locally when browsing the
   </a>
   <h1>Katharsis</h1>
 
-<a href="https://github.com/arghena/katharsis/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/arghena/katharsis/ci.yml?branch=v1.0.0-canary.30&style=for-the-badge&label=CI&labelColor=1a1b26&color=black&logo=github" alt="CI" /></a>
-<a href="https://coveralls.io/github/arghena/katharsis"><img src="https://img.shields.io/coverallsCoverage/github/arghena/katharsis?branch=v1.0.0-canary.30&style=for-the-badge&labelColor=1a1b26&color=ivory&logo=coveralls" alt="Coverage Status" /></a>
-<a href="https://github.com/arghena/katharsis/actions/workflows/cd.yml"><img src="https://img.shields.io/github/actions/workflow/status/arghena/katharsis/cd.yml?branch=v1.0.0-canary.30&style=for-the-badge&label=CD&labelColor=1a1b26&color=black&logo=github" alt="CD" /></a>
+<a href="https://github.com/arghena/katharsis/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/arghena/katharsis/ci.yml?branch=canary&style=for-the-badge&logo=github&label=ci&labelColor=1a1b26&color=000000" alt="CI" /></a>
+<a href="https://codecov.io/gh/arghena/katharsis"><img src="https://img.shields.io/codecov/c/github/arghena/katharsis/canary?style=for-the-badge&logo=codecov&label=coverage&labelColor=1a1b26&color=f01f7a" alt="Coverage" /></a>
+<a href="https://github.com/arghena/katharsis/releases/latest"><img src="https://img.shields.io/github/v/release/arghena/katharsis?include_prereleases&style=for-the-badge&logo=github&label=release&labelColor=1a1b26&color=000000" alt="Release" /></a>
 
 </div>
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,8 @@ enum Commands {
     Init,
 }
 
-#[tokio::main] // Order is important.
-#[cfg(not(tarpaulin_include))]
+#[tokio::main]
+#[cfg_attr(coverage_nightly, coverage(off))]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
     let mut path = PathBuf::from("katharsis.toml");


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!-- markdownlint-disable-file MD041 -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. Updated the CI workflow to use nightly Rust for coverage.
2. Cleaned up `insight.toml` config.
3. Updated README badges and Rust attributes.

### Description

<!-- Explain the reason for the changes -->

- **What does this PR do?**
  - EXPLAIN_HERE
- **Which issue does it resolve?**
  - Closes #ISSUE_NUMBER
- **Does this introduce breaking changes?**
  - EXPLAIN_HERE

### Additional Notes

<!-- Any additional information -->
