### PR TITLE
chore: move `shfmt` config to `.editorconfig` and cleanup scripts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,6 +18,12 @@ indent_size = 2
 [*.rs]
 max_line_length = 100
 
+[*.sh]
+simplify = true
+binary_next_line = true
+switch_case_indent = true
+space_redirects = true
+
 [*.md]
 # Double whitespace at end of line
 # denotes a line break in Markdown.

--- a/.github/insight.toml
+++ b/.github/insight.toml
@@ -26,7 +26,6 @@ shellcheck = ["etc/ci/*.sh"]
 
 [args.formatters]
 cargo-fmt = ["--all"]
-shfmt = ["-i", "4", "-ci"]
 
 [args.linters]
 cargo-clippy = ["--all-targets", "--locked", "--", "-D", "warnings"]

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -129,7 +129,7 @@ jobs:
         # attach any associated assets, and then publish the draft.
         # https://github.com/orgs/community/discussions/171210#discussioncomment-14237940
         run: |
-          if [[ $GITHUB_REF_NAME = *canary* ]]; then
+          if [[ $GITHUB_REF_NAME == *canary* ]]; then
             npx changelogithub@latest --prerelease --draft
           else
             npx changelogithub@latest --draft

--- a/etc/ci/before_deploy.sh
+++ b/etc/ci/before_deploy.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# TODO: Migrate to `cargo-deb`.
+# https://github.com/kornelski/cargo-deb
+
 # Copyright 2020 Dan Davison
 # Distributed under the [MIT License](https://github.com/dandavison/delta/blob/main/LICENSE).
 
@@ -10,7 +13,7 @@ pack() {
     local out_dir
     local package_name
 
-    tempdir=$(mktemp -d 2>/dev/null || mktemp -d -t tmp)
+    tempdir=$(mktemp -d 2> /dev/null || mktemp -d -t tmp)
     out_dir=$(pwd)
     package_name="$PROJECT_NAME-$GITHUB_REF_NAME-$TARGET"
 
@@ -22,7 +25,7 @@ pack() {
     cp LICENSE "$tempdir/$package_name"
 
     pushd "$tempdir"
-    if [[ $TARGET = *windows* ]]; then
+    if [[ $TARGET == *windows* ]]; then
         7z a "$out_dir/$package_name.zip" "$package_name"/*
     else
         tar czf "$out_dir/$package_name.tar.gz" "$package_name"/*
@@ -68,7 +71,7 @@ make_deb() {
     esac
     version=$(echo "$GITHUB_REF_NAME" | sed -e 's/^v//' -e 's/-canary/~canary/')
 
-    if [[ $TARGET = *musl* ]]; then
+    if [[ $TARGET == *musl* ]]; then
         dpkgname=$PROJECT_NAME-musl
         conflictname=$PROJECT_NAME
     else
@@ -76,17 +79,18 @@ make_deb() {
         conflictname=$PROJECT_NAME-musl
     fi
 
-    tempdir=$(mktemp -d 2>/dev/null || mktemp -d -t tmp)
+    tempdir=$(mktemp -d 2> /dev/null || mktemp -d -t tmp)
 
     install -Dm755 "target/$TARGET/release/$PROJECT_NAME" "$tempdir/usr/bin/$PROJECT_NAME"
 
+    # HACK: Work out shared library dependencies.
     mkdir "./debian"
     touch "./debian/control"
-    depends="$(dpkg-shlibdeps $library_dir -O "$tempdir/usr/bin/$PROJECT_NAME" 2>/dev/null | sed 's/^shlibs:Depends=//')"
+    depends="$(dpkg-shlibdeps $library_dir -O "$tempdir/usr/bin/$PROJECT_NAME" 2> /dev/null | sed 's/^shlibs:Depends=//')"
     rm -rf "./debian"
 
     install -Dm644 README.md "$tempdir/usr/share/doc/$dpkgname/README.md"
-    cat >"$tempdir/usr/share/doc/$dpkgname/copyright" <<EOF
+    cat > "$tempdir/usr/share/doc/$dpkgname/copyright" << EOF
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: $PROJECT_NAME
 Source: $homepage
@@ -123,7 +127,7 @@ EOF
     chmod 644 "$tempdir/usr/share/doc/$dpkgname/copyright"
 
     mkdir "$tempdir/DEBIAN"
-    cat >"$tempdir/DEBIAN/control" <<EOF
+    cat > "$tempdir/DEBIAN/control" << EOF
 Package: $dpkgname
 Version: $version
 Section: utils
@@ -140,7 +144,7 @@ EOF
 
 main() {
     pack
-    if [[ $TARGET = *linux* ]]; then
+    if [[ $TARGET == *linux* ]]; then
         make_deb
     fi
 }


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!-- markdownlint-disable-file MD041 -->

### Summary of Changes

<!-- Please include a summary of the changes -->

Moved the shell formatting rules into `.editorconfig` (added `space_redirects`, etc.) and applied the changes.

Also added a TODO about migrating to `cargo-deb` and a note about the shared lib dependency hack.

### Description

<!-- Explain the reason for the changes -->

- **What does this PR do?**
  - EXPLAIN_HERE
- **Which issue does it resolve?**
  - Closes #ISSUE_NUMBER
- **Does this introduce breaking changes?**
  - EXPLAIN_HERE

### Additional Notes

<!-- Any additional information -->
