### PR TITLE
ci(deps): bump arghena/insight from 0.1.0-canary.39 to 0.1.0-canary.43

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run Insight
-        uses: arghena/insight@91a232e5e8e6d3614f790d5df9174312c1a4432b # v0.1.0-canary.39
+        uses: arghena/insight@4a878098788e6e428254a80f9fcba04ba3cb7d60 # v0.1.0-canary.43

--- a/.github/workflows/check-pull-request-title.yml
+++ b/.github/workflows/check-pull-request-title.yml
@@ -18,6 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Insight
-        uses: arghena/insight@91a232e5e8e6d3614f790d5df9174312c1a4432b # v0.1.0-canary.39
+        uses: arghena/insight@4a878098788e6e428254a80f9fcba04ba3cb7d60 # v0.1.0-canary.43
         with:
           check-pull-request-title: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run Insight
-        uses: arghena/insight@91a232e5e8e6d3614f790d5df9174312c1a4432b # v0.1.0-canary.39
+        uses: arghena/insight@4a878098788e6e428254a80f9fcba04ba3cb7d60 # v0.1.0-canary.43


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!-- markdownlint-disable-file MD041 -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. CHANGE_SUMMARY

### Description

<!-- Explain the reason for the changes -->

- **What does this PR do?**
  - EXPLAIN_HERE
- **Which issue does it resolve?**
  - Closes #ISSUE_NUMBER
- **Does this introduce breaking changes?**
  - EXPLAIN_HERE

### Additional Notes

<!-- Any additional information -->
