### PR TITLE
ci: build aarch64 natively on `ubuntu-24.04-arm` runner

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,6 +29,9 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             use-cross: false
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            use-cross: false
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             use-cross: true
@@ -37,9 +40,6 @@ jobs:
             use-cross: true
           - os: ubuntu-latest
             target: arm-unknown-linux-gnueabihf
-            use-cross: true
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
             use-cross: true
     steps:
       - name: Checkout repository
@@ -64,11 +64,6 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y binutils-arm-linux-gnueabihf
-      - name: Install binutils for ARM64
-        if: ${{ matrix.job.target == 'aarch64-unknown-linux-gnu' }}
-        run: |
-          sudo apt update
-          sudo apt install -y binutils-aarch64-linux-gnu
       - name: Package final binary
         shell: bash
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             use-cross: false
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            use-cross: false
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             use-cross: true
@@ -50,9 +53,6 @@ jobs:
             use-cross: true
           - os: ubuntu-latest
             target: arm-unknown-linux-gnueabihf
-            use-cross: true
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
             use-cross: true
     steps:
       - name: Checkout repository

--- a/etc/ci/before_deploy.sh
+++ b/etc/ci/before_deploy.sh
@@ -58,7 +58,7 @@ make_deb() {
             ;;
         aarch64*)
             architecture=arm64
-            library_dir="-l/usr/aarch64-linux-gnu/lib"
+            library_dir=""
             ;;
         arm*hf)
             architecture=armhf


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!-- markdownlint-disable-file MD041 -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. CHANGE_SUMMARY

### Description

<!-- Explain the reason for the changes -->

- **What does this PR do?**
  - EXPLAIN_HERE
- **Which issue does it resolve?**
  - Closes #ISSUE_NUMBER
- **Does this introduce breaking changes?**
  - EXPLAIN_HERE

### Additional Notes

<!-- Any additional information -->

https://github.com/actions/partner-runner-images/blob/main/images/arm-ubuntu-24-image.md