### PR TITLE
ci: optimize cross-compilation for linux gnu and musl targets

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,13 +28,13 @@ jobs:
             target: aarch64-pc-windows-msvc
             use-cross: false
           - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            use-cross: false
-          - os: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
             use-cross: false
           - os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
+            target: x86_64-unknown-linux-gnu
+            use-cross: true
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
             use-cross: true
           - os: ubuntu-latest
             target: i686-unknown-linux-gnu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
             use-cross: false
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
-            use-cross: true
+            use-cross: false
           - os: ubuntu-latest
             target: i686-unknown-linux-gnu
             use-cross: true


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!-- markdownlint-disable-file MD041 -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. Enabled `use-cross` for Linux GNU targets (x86_64 & aarch64) in CD.
   The GitHub Actions runners (like ubuntu-latest) ship with a pretty new glibc. If we build natively, the release binaries will throw a "glibc version not found" error on older Linux distros. Using `cross` builds them inside a container with an older glibc, making our releases way more portable.
2. Disabled `use-cross` for Linux MUSL targets in CI and CD.
   Since musl is statically linked, we don't need to worry about glibc compatibility at all. Dropping `cross` here means we skip the extra Docker overhead, which makes the builds run much faster natively.

### Description

<!-- Explain the reason for the changes -->

- **What does this PR do?**
  - EXPLAIN_HERE
- **Which issue does it resolve?**
  - Closes #ISSUE_NUMBER
- **Does this introduce breaking changes?**
  - EXPLAIN_HERE

### Additional Notes

<!-- Any additional information -->
