### PR TITLE
build: configure cargo to deny warnings globally and use `--keep-going` for clippy

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,6 @@
+[build]
+warnings = "deny"
+
 # NOTE: Statically link CRT to avoid vcruntime DLL dependencies.
 # https://github.com/microsoft/winget-pkgs/pull/207941#issuecomment-2575712665
 [target.'cfg(all(target_os = "windows", target_env = "msvc"))']

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -132,7 +132,7 @@ All pull request submissions to this project must comply with the [DCO](https://
 
    ```bash
    cargo fmt --all --check
-   cargo clippy --all-targets --locked -- -D warnings
+   cargo clippy --all-targets --keep-going --locked
    ```
 
 1. Run tests:

--- a/.github/insight.toml
+++ b/.github/insight.toml
@@ -28,6 +28,6 @@ shellcheck = ["etc/ci/*.sh"]
 cargo-fmt = ["--all"]
 
 [args.linters]
-cargo-clippy = ["--all-targets", "--locked", "--", "-D", "warnings"]
+cargo-clippy = ["--all-targets", "--keep-going", "--locked"]
 yamllint = ["--strict"]
 tombi = ["--error-on-warnings"]


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!-- markdownlint-disable-file MD041 -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. CHANGE_SUMMARY

### Description

<!-- Explain the reason for the changes -->

- **What does this PR do?**
  - EXPLAIN_HERE
- **Which issue does it resolve?**
  - Closes #ISSUE_NUMBER
- **Does this introduce breaking changes?**
  - EXPLAIN_HERE

### Additional Notes

<!-- Any additional information -->

https://blog.rust-lang.org/2026/07/09/Rust-1.97.0/#cargo-support-for-denying-warnings