### PR TITLE
fix: correct rss timezone, prompt case, and optimize sorting

### DIFF
--- a/src/arg/handle.rs
+++ b/src/arg/handle.rs
@@ -1,11 +1,11 @@
 use crate::error::app::Errors;
 use anyhow::Result;
-use chrono::{DateTime, Local, NaiveDate};
+use chrono::{DateTime, NaiveDate, Utc};
 use glob::{GlobResult, glob};
 use rss::{Channel, ChannelBuilder, Enclosure, Guid, Image, Item};
 use scraper::{Html, Selector};
 use serde::Deserialize;
-use std::path::PathBuf;
+use std::{cmp, path::PathBuf};
 use tokio::io::AsyncWriteExt;
 use tokio::{fs, fs::File};
 use url::Url;
@@ -88,17 +88,12 @@ pub async fn builder(config_path: &PathBuf) -> Result<Channel, Errors> {
         }
 
         if article.sort {
-            items.sort_by(|a, b| {
-                let a_date = a
-                    .pub_date
-                    .as_ref()
-                    .and_then(|d| DateTime::parse_from_rfc2822(d).ok());
-                let b_date = b
-                    .pub_date
-                    .as_ref()
-                    .and_then(|d| DateTime::parse_from_rfc2822(d).ok());
-
-                b_date.cmp(&a_date)
+            items.sort_by_cached_key(|item| {
+                cmp::Reverse(
+                    item.pub_date
+                        .as_ref()
+                        .and_then(|d| DateTime::parse_from_rfc2822(d).ok()),
+                )
             });
         }
 
@@ -107,7 +102,7 @@ pub async fn builder(config_path: &PathBuf) -> Result<Channel, Errors> {
         let mut rss_file = File::create(&rss.output).await?;
         let channel = channel_builder(rss, items);
 
-        rss_file.write_all(channel.to_string().as_ref()).await?;
+        rss_file.write_all(channel.to_string().as_bytes()).await?;
 
         Ok(channel)
     } else {
@@ -227,6 +222,6 @@ fn channel_builder(rss: Rss, items: Vec<Item>) -> Channel {
         .items(items)
         .docs(String::from("https://validator.w3.org/feed/docs/rss2.html"))
         .generator(String::from("https://github.com/arghena/katharsis"))
-        .last_build_date(Local::now().format("%a, %d %b %Y %H:%M:%S GMT").to_string())
+        .last_build_date(Utc::now().format("%a, %d %b %Y %H:%M:%S GMT").to_string())
         .build()
 }

--- a/src/cmd/handle.rs
+++ b/src/cmd/handle.rs
@@ -36,7 +36,7 @@ pub async fn init(path: &PathBuf) -> Result<(), Errors> {
         let options: Vec<&str> = vec!["Yes", "No"];
         let ans: &str = Select::new("A katharsis.toml already exists in the current directory. Do you want to overwrite it?", options).prompt()?;
 
-        if ans == "yes" {
+        if ans == "Yes" {
             fs::write(path, config_bytes).await?;
         }
     } else {


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!-- markdownlint-disable-file MD041 -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. Fix RSS timezone generation (Local -> UTC).
2. Fix config overwrite prompt case sensitivity.
3. Optimize RSS item sorting.

### Description

<!-- Explain the reason for the changes -->

- **What does this PR do?**
  - Changes the RSS build date to use `Utc::now()` to avoid local timezone offset bugs.
  - Fixes the `init` command so overwriting the config actually works (matches "Yes" exactly).
  - Refactors sorting to use `sort_by_cached_key`, which stops redundant date parsing during comparisons.
  - Changes `.as_ref()` to `.as_bytes()` when writing to the file for more idiomatic Rust.
- **Which issue does it resolve?**
  - Closes #ISSUE_NUMBER
- **Does this introduce breaking changes?**
  - No.

### Additional Notes

<!-- Any additional information -->

None.
